### PR TITLE
update for debug info symbols in pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG VERSION
+FROM mariadb:$VERSION
+ARG VERSION
+# 5.5 - trusty
+# 10.0 - xenial
+# 10.1 - bionic ...
+# 10.3 - focal ...
+# 10.8+ jammy ...
+ARG REL
+
+# older 10.2 versions
+#RUN echo "deb https://archive.mariadb.org/mariadb-$VERSION/repo/ubuntu $REL main main/debug" > /etc/apt/sources.list.d/mariadb-debug.list
+# newer versions
+RUN sed -i -e 's/main/main main\/debug/' /etc/apt/sources.list.d/mariadb.list
+
+# Much newer versions don't need VM
+# pre 10.9
+RUN apt-get update \
+	&& VM=$VERSION && VM=${VM%.*} \
+        && apt-get install -y linux-tools-common mariadb-server-core-${VM}-dbgsym ; \
+        rm -rf /var/lib/apt/lists/*
+
+# 10.9+
+#RUN apt-get update \
+#        && apt-get install -y linux-tools-common mariadb-server-core-dbgsym ; \
+#        rm -rf /var/lib/apt/lists/*

--- a/bench.sh
+++ b/bench.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-export MARIADB_VERSION=${1:-10.2.37}
-
-docker compose up -d --wait
+export MARIADB_VERSION=10.4.18
+docker compose up
 docker compose exec -T mariadb mysql -u root -p'root' magentodb < magentodb.sql
+echo " # MariaDB Version check:"
+docker compose exec mariadb mysql -u root -p'root' magentodb -e 'SELECT VERSION()'
 echo " # MariaDB $MARIADB_VERSION - request start: $(date)"
 time docker-compose exec -T mariadb mysql -u myuser -p'mypass' < request.sql > /dev/null
 echo " # MariaDB $MARIADB_VERSION - request end: $(date)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
 version: '3'
 services:
   mariadb:
-    image: mariadb:${MARIADB_VERSION:-10.2.37}
+    image: mariadb:${MARIADB_VERSION:-10.4.18}
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${MARIADB_VERSION}
+        REL: focal
     volumes:
       - ./tuning.cnf:/etc/mysql/conf.d/tuning.cnf
     environment:
@@ -10,7 +16,7 @@ services:
       MYSQL_USER: myuser
       MYSQL_PASSWORD: mypass
     healthcheck:
-        test: ["CMD-SHELL", "mysqladmin -p${MYSQL_ROOT_PASSWORD:-nopassword} ping"]
+        test: ["CMD-SHELL", "healthcheck.sh", "--connect"]
         interval: 20s
         timeout: 5s
         retries: 5


### PR DESCRIPTION
this is an incomplete update to have debug symbols in the container.

I think you need to copy out
```
root@55228bb5c8d9:/# find^C
root@55228bb5c8d9:/# dpkg -l | grep dbg
ii  mariadb-server-core-10.3-dbgsym 1:10.3.39+maria~ubu2004      amd64        debug symbols for mariadb-server-core-10.3
root@55228bb5c8d9:/# dpkg -L mariadb-server-core-10.3-dbgsym 
/.
/usr
/usr/lib
/usr/lib/debug
/usr/lib/debug/.build-id
/usr/lib/debug/.build-id/28
/usr/lib/debug/.build-id/28/8ee0c88019bc1bb0d896a5dde6115ec77f9775.debug
/usr/lib/debug/.build-id/6f
/usr/lib/debug/.build-id/6f/3e29bfb790f0a5da3aa728a7c8d541e4077ef8.debug
/usr/lib/debug/.build-id/da
/usr/lib/debug/.build-id/da/5eb65cd167958e6d83dda00a19602a7431f3c0.debug
/usr/share
/usr/share/doc
/usr/share/doc/mariadb-server-core-10.3-dbgsym
```

```
perf report --symfs=
```
I thin the /usr/lib/debug path needs to be copied out of the build container to generate a build report.